### PR TITLE
adds encryption key capacity for headphones

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/misc.yml
@@ -4,6 +4,16 @@
   name: headphones
   description: Quality headphones from Drunk Masters, with good sound insulation.
   components:
+  - type: ContainerContainer
+    containers:
+      key_slots: !type:Container
+  - type: ContainerFill
+    containers:
+      key_slots:
+      - EncryptionKeyCommon
+  - type: Headset
+  - type: EncryptionKeyHolder
+    keySlots: 4
   - type: Sprite
     sprite: Clothing/Multiple/headphones.rsi
     layers:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
added container components to allow headphones to take and use encryption keys as radio.

## Why / Balance
headphones have the functionality to be worn on the ear, but would never replace a comms headpiece as is.

## Technical details
copy-pasted the headset components from the default headset

## Media


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
-add can now insert encryption keys into headphones
